### PR TITLE
OP#36674 Validate existence of OP instance before adding 

### DIFF
--- a/src/OpenProject/WebViewIntegration/LandingPage/index.html
+++ b/src/OpenProject/WebViewIntegration/LandingPage/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en-US" dir="ltr" class="wf-lato-n3-active wf-lato-n4-active wf-active">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/src/OpenProject/WebViewIntegration/OpenProjectInstanceValidator.cs
+++ b/src/OpenProject/WebViewIntegration/OpenProjectInstanceValidator.cs
@@ -64,26 +64,30 @@ namespace OpenProject.WebViewIntegration
 
     private static string GetInstanceUrl(string instanceNameOrUrl)
     {
-      if (Uri.TryCreate(instanceNameOrUrl, UriKind.Absolute, out var _)
-        && Regex.IsMatch(instanceNameOrUrl.ToLower(), "^https?://"))
+      const string apiPathSuffix = "/api/v3";
+      bool hasApiSuffix = instanceNameOrUrl.TrimEnd('/').EndsWith(apiPathSuffix, StringComparison.InvariantCultureIgnoreCase);
+
+      string appendSuffix(string uri)
       {
-        return instanceNameOrUrl;
+        string suffix = hasApiSuffix ? "" : apiPathSuffix;
+        return uri + suffix;
       }
 
-      var subDomainRegexPattern = "^[a-zA-Z0-9-]+$";
+      if (Uri.TryCreate(instanceNameOrUrl, UriKind.Absolute, out Uri instanceUri)
+        && Regex.IsMatch(instanceUri.Scheme, "^https?$"))
+      {
+        return appendSuffix(instanceUri.AbsoluteUri.TrimEnd('/'));
+      }
+
+      string subDomainRegexPattern = "^[a-zA-Z0-9-]+$";
       if (Regex.IsMatch(instanceNameOrUrl, subDomainRegexPattern))
       {
-        return $"https://{instanceNameOrUrl}.openproject.com/api/v3";
+        return $"https://{instanceNameOrUrl}.openproject.com{apiPathSuffix}";
       }
 
-      if (Uri.TryCreate($"https://{instanceNameOrUrl}", UriKind.Absolute, out var instanceUri))
+      if (Uri.TryCreate($"https://{instanceNameOrUrl}", UriKind.Absolute, out instanceUri))
       {
-        if (!instanceUri.PathAndQuery.TrimEnd('/').EndsWith("/api/v3", StringComparison.InvariantCultureIgnoreCase))
-        {
-          return $"https://{instanceNameOrUrl.TrimEnd('/')}/api/v3";
-        }
-
-        return $"https://{instanceNameOrUrl}";
+        return appendSuffix(instanceUri.AbsoluteUri.TrimEnd('/'));
       }
 
       return null;

--- a/src/OpenProject/WebViewIntegration/OpenProjectInstanceValidator.cs
+++ b/src/OpenProject/WebViewIntegration/OpenProjectInstanceValidator.cs
@@ -65,21 +65,21 @@ namespace OpenProject.WebViewIntegration
     private static string GetInstanceUrl(string instanceNameOrUrl)
     {
       const string apiPathSuffix = "/api/v3";
-      bool hasApiSuffix = instanceNameOrUrl.TrimEnd('/').EndsWith(apiPathSuffix, StringComparison.InvariantCultureIgnoreCase);
+      var hasApiSuffix = instanceNameOrUrl.TrimEnd('/').EndsWith(apiPathSuffix, StringComparison.InvariantCultureIgnoreCase);
 
       string appendSuffix(string uri)
       {
-        string suffix = hasApiSuffix ? "" : apiPathSuffix;
+        var suffix = hasApiSuffix ? "" : apiPathSuffix;
         return uri + suffix;
       }
 
-      if (Uri.TryCreate(instanceNameOrUrl, UriKind.Absolute, out Uri instanceUri)
+      if (Uri.TryCreate(instanceNameOrUrl, UriKind.Absolute, out var instanceUri)
         && Regex.IsMatch(instanceUri.Scheme, "^https?$"))
       {
         return appendSuffix(instanceUri.AbsoluteUri.TrimEnd('/'));
       }
 
-      string subDomainRegexPattern = "^[a-zA-Z0-9-]+$";
+      var subDomainRegexPattern = "^[a-zA-Z0-9-]+$";
       if (Regex.IsMatch(instanceNameOrUrl, subDomainRegexPattern))
       {
         return $"https://{instanceNameOrUrl}.openproject.com{apiPathSuffix}";

--- a/test/OpenProject.Tests/WebViewIntegration/OpenProjectInstanceValidatorTests.cs
+++ b/test/OpenProject.Tests/WebViewIntegration/OpenProjectInstanceValidatorTests.cs
@@ -15,8 +15,8 @@ namespace OpenProject.Tests.WebViewIntegration
       [InlineData("https://wieland.openproject.com/api/v3", "https://wieland.openproject.com")]
       [InlineData("https://community.openproject.org/api/v3/", "https://community.openproject.org")]
       [InlineData("https://wieland.openproject.com/api/v3/", "https://wieland.openproject.com")]
-      [InlineData("https://community.openproject.org:443/api/v3", "https://community.openproject.org:443")]
-      [InlineData("https://wieland.openproject.com:443/api/v3", "https://wieland.openproject.com:443")]
+      [InlineData("https://community.openproject.org:443/api/v3", "https://community.openproject.org")]
+      [InlineData("https://wieland.openproject.com:443/api/v3", "https://wieland.openproject.com")]
       public async Task ReturnsTrueForActualInstances(string instanceUrl, string expectedBaseUrl)
       {
         var actual = await OpenProjectInstanceValidator.IsValidOpenProjectInstanceAsync(instanceUrl);
@@ -51,12 +51,35 @@ namespace OpenProject.Tests.WebViewIntegration
       [InlineData("wieland.openproject.com/", "https://wieland.openproject.com")]
       [InlineData("community.openproject.org", "https://community.openproject.org")]
       [InlineData("wieland.openproject.com", "https://wieland.openproject.com")]
-      [InlineData("community.openproject.org:443", "https://community.openproject.org:443")]
+      [InlineData("community.openproject.org:443", "https://community.openproject.org")]
       public async Task ReturnsTrueForJustTheUrlWithoutProtocol_WithoutApiPath(string instanceUrl, string expectedBaseUrl)
       {
         var actual = await OpenProjectInstanceValidator.IsValidOpenProjectInstanceAsync(instanceUrl);
         Assert.True(actual.isValid);
         Assert.Equal(expectedBaseUrl, actual.instanceBaseUrl);
+      }
+
+      [Theory]
+      [InlineData("https://community.openproject.org/", "https://community.openproject.org")]
+      [InlineData("https://wieland.openproject.com/", "https://wieland.openproject.com")]
+      [InlineData("https://community.openproject.org", "https://community.openproject.org")]
+      [InlineData("https://wieland.openproject.com", "https://wieland.openproject.com")]
+      [InlineData("https://community.openproject.org:443", "https://community.openproject.org")]
+      public async Task ReturnsTrueForJustTheUrlWithProtocol_WithoutApiPath(string instanceUrl, string expectedBaseUrl)
+      {
+        var actual = await OpenProjectInstanceValidator.IsValidOpenProjectInstanceAsync(instanceUrl);
+        Assert.True(actual.isValid);
+        Assert.Equal(expectedBaseUrl, actual.instanceBaseUrl);
+      }
+
+      [Theory]
+      [InlineData("file:///some/strange/human/providing/strange/urls.txt")]
+      [InlineData("wss://javascript.info")]
+      public async Task ReturnsFalseForUrlWithoutHttoScheme(string instanceUrl)
+      {
+        var actual = await OpenProjectInstanceValidator.IsValidOpenProjectInstanceAsync(instanceUrl);
+        Assert.False(actual.isValid);
+        Assert.Null(actual.instanceBaseUrl);
       }
 
       [Theory]


### PR DESCRIPTION
https://community.openproject.org/work_packages/36674

Fixed:
- Adding URLs **WITH** HTTP scheme, but **WITHOUT** API path suffix now validates correctly.

Added:
- New test cases added for URLs without HTTP scheme.