### PR TITLE
Added IoC for the open project instance validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,9 @@ FakesAssemblies/
 # Visual Studio 6 workspace options file
 *.opt
 
+# JetBrains IDE configuration files
+.idea/
+
 output/
 
 Bcfier/WebViewIntegration/LandingPage/LandingPage.zip

--- a/src/OpenProject/UserControls/BcfierPanel.xaml
+++ b/src/OpenProject/UserControls/BcfierPanel.xaml
@@ -2,12 +2,9 @@
   x:Class="OpenProject.UserControls.BcfierPanel"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:ctr="clr-namespace:OpenProject.UserControls"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-  xmlns:data="clr-namespace:OpenProject.Data"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:src="clr-namespace:OpenProject.Data.ValueConverters"
-  xmlns:themes="clr-namespace:OpenProject.Themes"
   xmlns:wpf="clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf"
   mc:Ignorable="d">
   <UserControl.Resources>
@@ -28,7 +25,6 @@
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="*" />
     </Grid.ColumnDefinitions>
-    <wpf:ChromiumWebBrowser x:Name="Browser">
-    </wpf:ChromiumWebBrowser>
+    <wpf:ChromiumWebBrowser x:Name="Browser" />
   </Grid>
 </UserControl>

--- a/src/OpenProject/WebViewIntegration/LandingPage/index.html
+++ b/src/OpenProject/WebViewIntegration/LandingPage/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en-US" dir="ltr" class="wf-lato-n3-active wf-lato-n4-active wf-active">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/src/OpenProject/WebViewIntegration/OpenProjectInstanceValidator.cs
+++ b/src/OpenProject/WebViewIntegration/OpenProjectInstanceValidator.cs
@@ -64,26 +64,30 @@ namespace OpenProject.WebViewIntegration
 
     private static string GetInstanceUrl(string instanceNameOrUrl)
     {
-      if (Uri.TryCreate(instanceNameOrUrl, UriKind.Absolute, out var _)
-        && Regex.IsMatch(instanceNameOrUrl.ToLower(), "^https?://"))
+      const string apiPathSuffix = "/api/v3";
+      bool hasApiSuffix = instanceNameOrUrl.TrimEnd('/').EndsWith(apiPathSuffix, StringComparison.InvariantCultureIgnoreCase);
+
+      string appendSuffix(string uri)
       {
-        return instanceNameOrUrl;
+        string suffix = hasApiSuffix ? "" : apiPathSuffix;
+        return uri + suffix;
       }
 
-      var subDomainRegexPattern = "^[a-zA-Z0-9-]+$";
+      if (Uri.TryCreate(instanceNameOrUrl, UriKind.Absolute, out Uri instanceUri)
+        && Regex.IsMatch(instanceUri.Scheme, "^https?$"))
+      {
+        return appendSuffix(instanceUri.AbsoluteUri.TrimEnd('/'));
+      }
+
+      string subDomainRegexPattern = "^[a-zA-Z0-9-]+$";
       if (Regex.IsMatch(instanceNameOrUrl, subDomainRegexPattern))
       {
-        return $"https://{instanceNameOrUrl}.openproject.com/api/v3";
+        return $"https://{instanceNameOrUrl}.openproject.com{apiPathSuffix}";
       }
 
-      if (Uri.TryCreate($"https://{instanceNameOrUrl}", UriKind.Absolute, out var instanceUri))
+      if (Uri.TryCreate($"https://{instanceNameOrUrl}", UriKind.Absolute, out instanceUri))
       {
-        if (!instanceUri.PathAndQuery.TrimEnd('/').EndsWith("/api/v3", StringComparison.InvariantCultureIgnoreCase))
-        {
-          return $"https://{instanceNameOrUrl.TrimEnd('/')}/api/v3";
-        }
-
-        return $"https://{instanceNameOrUrl}";
+        return appendSuffix(instanceUri.AbsoluteUri.TrimEnd('/'));
       }
 
       return null;

--- a/src/OpenProject/WebViewIntegration/OpenProjectInstanceValidator.cs
+++ b/src/OpenProject/WebViewIntegration/OpenProjectInstanceValidator.cs
@@ -65,21 +65,21 @@ namespace OpenProject.WebViewIntegration
     private static string GetInstanceUrl(string instanceNameOrUrl)
     {
       const string apiPathSuffix = "/api/v3";
-      bool hasApiSuffix = instanceNameOrUrl.TrimEnd('/').EndsWith(apiPathSuffix, StringComparison.InvariantCultureIgnoreCase);
+      var hasApiSuffix = instanceNameOrUrl.TrimEnd('/').EndsWith(apiPathSuffix, StringComparison.InvariantCultureIgnoreCase);
 
       string appendSuffix(string uri)
       {
-        string suffix = hasApiSuffix ? "" : apiPathSuffix;
+        var suffix = hasApiSuffix ? "" : apiPathSuffix;
         return uri + suffix;
       }
 
-      if (Uri.TryCreate(instanceNameOrUrl, UriKind.Absolute, out Uri instanceUri)
+      if (Uri.TryCreate(instanceNameOrUrl, UriKind.Absolute, out var instanceUri)
         && Regex.IsMatch(instanceUri.Scheme, "^https?$"))
       {
         return appendSuffix(instanceUri.AbsoluteUri.TrimEnd('/'));
       }
 
-      string subDomainRegexPattern = "^[a-zA-Z0-9-]+$";
+      var subDomainRegexPattern = "^[a-zA-Z0-9-]+$";
       if (Regex.IsMatch(instanceNameOrUrl, subDomainRegexPattern))
       {
         return $"https://{instanceNameOrUrl}.openproject.com{apiPathSuffix}";

--- a/test/OpenProject.Tests/Mocks/MockHttpClient.cs
+++ b/test/OpenProject.Tests/Mocks/MockHttpClient.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+
+namespace OpenProject.Tests.Mocks
+{
+  internal class MockHttpClient
+  {
+    internal HttpClient GetMockClient(Dictionary<string, string> successResponses)
+    {
+      var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+      mockHttpMessageHandler.Protected()
+          .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+          .Returns((HttpRequestMessage request, CancellationToken cancellationToken) => GetMockResponse(request, successResponses));
+      return new HttpClient(mockHttpMessageHandler.Object);
+    }
+
+    private Task<HttpResponseMessage> GetMockResponse(HttpRequestMessage request, IDictionary<string, string> successResponses)
+    {
+      var code = HttpStatusCode.InternalServerError;
+      var content = "";
+
+      if (successResponses.TryGetValue(request.RequestUri.AbsoluteUri.ToLowerInvariant(), out content))
+      {
+        code = HttpStatusCode.OK;
+      }
+
+      var response = new HttpResponseMessage(code)
+      {
+        Content = new StringContent(content, Encoding.UTF8, "application/json")
+      };
+      return Task.FromResult(response);
+    }
+  }
+}

--- a/test/OpenProject.Tests/OpenProject.Tests.csproj
+++ b/test/OpenProject.Tests/OpenProject.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/test/OpenProject.Tests/WebViewIntegration/OpenProjectInstanceValidatorIntegrationTest.cs
+++ b/test/OpenProject.Tests/WebViewIntegration/OpenProjectInstanceValidatorIntegrationTest.cs
@@ -1,0 +1,34 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using OpenProject.WebViewIntegration;
+using Xunit;
+
+namespace OpenProject.Tests.WebViewIntegration
+{
+  /// <summary>
+  /// This test suite runs the <see cref="OpenProjectInstanceValidator"/> against a real external running instance of
+  /// the OpenProject API.
+  /// </summary>
+  public class OpenProjectInstanceValidatorIntegrationTest
+  {
+    [Fact]
+    public async Task ReturnsTrueForExternalRunningInstance()
+    {
+      // Arrange
+      var factoryMock = new Mock<IHttpClientFactory>();
+      factoryMock.Setup(x => x.CreateClient(It.IsAny<string>()))
+        .Returns((string name) => new HttpClient());
+
+      var validator = new OpenProjectInstanceValidator(factoryMock.Object);
+
+      // Act
+      var (isValid, instanceBaseUrl) = await validator
+        .IsValidOpenProjectInstanceAsync("https://wieland.openproject.com");
+
+      // Assert
+      Assert.True(isValid);
+      Assert.Equal("https://wieland.openproject.com", instanceBaseUrl);
+    }
+  }
+}

--- a/test/OpenProject.Tests/WebViewIntegration/OpenProjectInstanceValidatorTests.cs
+++ b/test/OpenProject.Tests/WebViewIntegration/OpenProjectInstanceValidatorTests.cs
@@ -15,8 +15,8 @@ namespace OpenProject.Tests.WebViewIntegration
       [InlineData("https://wieland.openproject.com/api/v3", "https://wieland.openproject.com")]
       [InlineData("https://community.openproject.org/api/v3/", "https://community.openproject.org")]
       [InlineData("https://wieland.openproject.com/api/v3/", "https://wieland.openproject.com")]
-      [InlineData("https://community.openproject.org:443/api/v3", "https://community.openproject.org:443")]
-      [InlineData("https://wieland.openproject.com:443/api/v3", "https://wieland.openproject.com:443")]
+      [InlineData("https://community.openproject.org:443/api/v3", "https://community.openproject.org")]
+      [InlineData("https://wieland.openproject.com:443/api/v3", "https://wieland.openproject.com")]
       public async Task ReturnsTrueForActualInstances(string instanceUrl, string expectedBaseUrl)
       {
         var actual = await OpenProjectInstanceValidator.IsValidOpenProjectInstanceAsync(instanceUrl);
@@ -51,12 +51,35 @@ namespace OpenProject.Tests.WebViewIntegration
       [InlineData("wieland.openproject.com/", "https://wieland.openproject.com")]
       [InlineData("community.openproject.org", "https://community.openproject.org")]
       [InlineData("wieland.openproject.com", "https://wieland.openproject.com")]
-      [InlineData("community.openproject.org:443", "https://community.openproject.org:443")]
+      [InlineData("community.openproject.org:443", "https://community.openproject.org")]
       public async Task ReturnsTrueForJustTheUrlWithoutProtocol_WithoutApiPath(string instanceUrl, string expectedBaseUrl)
       {
         var actual = await OpenProjectInstanceValidator.IsValidOpenProjectInstanceAsync(instanceUrl);
         Assert.True(actual.isValid);
         Assert.Equal(expectedBaseUrl, actual.instanceBaseUrl);
+      }
+
+      [Theory]
+      [InlineData("https://community.openproject.org/", "https://community.openproject.org")]
+      [InlineData("https://wieland.openproject.com/", "https://wieland.openproject.com")]
+      [InlineData("https://community.openproject.org", "https://community.openproject.org")]
+      [InlineData("https://wieland.openproject.com", "https://wieland.openproject.com")]
+      [InlineData("https://community.openproject.org:443", "https://community.openproject.org")]
+      public async Task ReturnsTrueForJustTheUrlWithProtocol_WithoutApiPath(string instanceUrl, string expectedBaseUrl)
+      {
+        var actual = await OpenProjectInstanceValidator.IsValidOpenProjectInstanceAsync(instanceUrl);
+        Assert.True(actual.isValid);
+        Assert.Equal(expectedBaseUrl, actual.instanceBaseUrl);
+      }
+
+      [Theory]
+      [InlineData("file:///some/strange/human/providing/strange/urls.txt")]
+      [InlineData("wss://javascript.info")]
+      public async Task ReturnsFalseForUrlWithoutHttoScheme(string instanceUrl)
+      {
+        var actual = await OpenProjectInstanceValidator.IsValidOpenProjectInstanceAsync(instanceUrl);
+        Assert.False(actual.isValid);
+        Assert.Null(actual.instanceBaseUrl);
       }
 
       [Theory]


### PR DESCRIPTION
This is a first try to add some IoC to the stack. In this draft we have added ctor dependencies to the `OpenProjectInstanceValidator` and updated then the tests to be fully encapsuled unit tests with mocked dependencies. 

We did NOT introduce a full fletched DI yet. This is due to some difficulties to apply the MVVM pattern to the few components we have here.